### PR TITLE
Feature/Reminders testing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Laravel CI
 
 on:
   push:
-    branches: [ main, develop, 'feature/login-testing' ]
+    branches: [ main, develop, 'feature/login-testing', 'feature/reminders-testing', 'feature/queue-type-testing' ]
   pull_request:
     branches: [ main, develop]
 

--- a/.idea/SeeQ-backend.iml
+++ b/.idea/SeeQ-backend.iml
@@ -6,6 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$/database/factories" isTestSource="false" packagePrefix="Database\Factories\" />
       <sourceFolder url="file://$MODULE_DIR$/database/seeders" isTestSource="false" packagePrefix="Database\Seeders\" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Tests\" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/aws/aws-crt-php" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/aws/aws-sdk-php" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/brick/math" />

--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpTestFrameworkVersionCache">
+    <tools_cache>
+      <tool tool_name="PHPUnit">
+        <cache>
+          <versions>
+            <info id="Local/vendor/autoload.php" version="11.5.10" />
+          </versions>
+        </cache>
+      </tool>
+    </tools_cache>
+  </component>
+</project>

--- a/app/Http/Controllers/ReminderController.php
+++ b/app/Http/Controllers/ReminderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Repositories\ReminderRepository;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class ReminderController extends Controller
 {
@@ -47,12 +48,19 @@ class ReminderController extends Controller
         }
     }
     public function markAsDone($id){
-        $shopId = (int)$id;
-        if (!$shopId) {
-            return response()->json(['error' => 'shop_id is required'], 400);
+        if (!is_numeric($id) || (int)$id <= 0) {
+            return response()->json(['error' => 'Invalid reminder ID'], Response::HTTP_BAD_REQUEST);
         }
-        return $this->reminderRepository->markAsDone($shopId);
+
+        $updated = $this->reminderRepository->markAsDone((int)$id);
+
+        if (!$updated) {
+            return response()->json(['error' => 'Reminder not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json(['message' => 'Reminder marked as completed'], Response::HTTP_OK);
     }
+
 
 
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,7 +99,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
 Route::get('/shops/reminders/{shop_id}', [ReminderController::class, 'show'])->name('reminders.show');
 Route::post('/shops/reminders', [ReminderController::class, 'store'])->name('reminders.store');
-Route::patch('/shops/reminders/{shop_id}', [ReminderController::class, 'markAsDone'])->name('reminders.update');
+Route::patch('/shops/reminders/{reminder_id}', [ReminderController::class, 'markAsDone'])->name('reminders.update');
 
 
 

--- a/tests/Feature/ShopRemindersTest.php
+++ b/tests/Feature/ShopRemindersTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Reminder;
+use App\Models\User;
+use App\Repositories\ReminderRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Mockery;
+
+class ShopRemindersTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    private $reminderRepository;
+    private $shopUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a shop user
+        $this->shopUser = User::factory()->state([
+            'role' => 'SHOP'
+        ])->create();
+
+        $this->reminderRepository = Mockery::mock(ReminderRepository::class);
+        $this->app->instance(ReminderRepository::class, $this->reminderRepository);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * Test when shop's reminders exist, system displays all pending reminders
+     */
+    public function test_when_shop_reminders_exist_system_displays_pending_reminders()
+    {
+        // Arrange
+        $shopId = $this->shopUser->id;
+        $remindersList = [
+            [
+                'id' => 1,
+                'shop_id' => $shopId,
+                'title' => 'First Reminder',
+                'description' => 'Description for first reminder',
+                'due_date' => now()->addDays(2)->toISOString(),
+                'status' => 'pending'
+            ],
+            [
+                'id' => 2,
+                'shop_id' => $shopId,
+                'title' => 'Second Reminder',
+                'description' => 'Description for second reminder',
+                'due_date' => now()->addDays(5)->toISOString(),
+                'status' => 'pending'
+            ]
+        ];
+
+
+        // Mock the repository method
+        $this->reminderRepository
+            ->shouldReceive('getAllRemindersByShopId')
+            ->with($shopId)
+            ->once()
+            ->andReturn(collect($remindersList));
+
+        // Act - Use actingAs to simulate authenticated user
+        $response = $this->actingAs($this->shopUser)
+            ->getJson("/api/shops/reminders/{$shopId}");
+
+        // Assert
+        $response->assertStatus(200)
+            ->assertJson($remindersList)
+            ->assertJsonCount(2);
+    }
+
+    /**
+     * Test when no shop's reminders exist, system displays message
+     */
+    public function test_when_no_shop_reminders_exist_system_displays_no_reminders_message()
+    {
+        // Arrange
+        $shopId = $this->shopUser->id;
+
+        // Mock the repository method
+        $this->reminderRepository
+            ->shouldReceive('getAllRemindersByShopId')
+            ->with($shopId)
+            ->once()
+            ->andReturn(collect([]));
+
+        // Act - Use actingAs to simulate authenticated user
+        $response = $this->actingAs($this->shopUser)
+            ->getJson("/api/shops/reminders/{$shopId}");
+
+        // Assert
+        $response->assertStatus(200)
+            ->assertJson([])
+            ->assertJsonCount(0);
+    }
+
+    /**
+     * Test when merchant creates a reminder, system displays the latest reminder
+     */
+    public function test_when_merchant_creates_reminder_system_displays_latest_reminder()
+    {
+        // Arrange
+        $shopId = $this->shopUser->id;
+        $reminderData = [
+            'shop_id' => $shopId,
+            'title' => 'New Reminder',
+            'description' => 'Description for new reminder',
+            'due_date' => now()->addDays(7)->format('Y-m-d H:i:s')
+        ];
+
+        $createdReminder = array_merge($reminderData, [
+            'id' => 3,
+            'status' => 'pending',
+            'created_at' => now()->format('Y-m-d H:i:s'),
+            'updated_at' => now()->format('Y-m-d H:i:s')
+        ]);
+
+        // Mock the repository method
+        $this->reminderRepository
+            ->shouldReceive('create')
+            ->with(Mockery::on(function($arg) use ($reminderData) {
+                return $arg['shop_id'] == $reminderData['shop_id'] &&
+                    $arg['title'] == $reminderData['title'] &&
+                    $arg['description'] == $reminderData['description'] &&
+                    isset($arg['due_date']);
+            }))
+            ->once()
+            ->andReturn($createdReminder);
+
+        // Act - Use actingAs to simulate authenticated user
+        $response = $this->actingAs($this->shopUser)
+            ->postJson('/api/shops/reminders', $reminderData);
+
+        // Assert
+        $response->assertStatus(200)
+            ->assertJson($createdReminder);
+    }
+
+    /**
+     * Test validation for creating a reminder
+     */
+    public function test_reminder_creation_validates_required_fields()
+    {
+        // Arrange
+        $invalidData = [
+            'shop_id' => '',
+            'title' => '',
+            'description' => '',
+            'due_date' => 'not-a-date'
+        ];
+
+        // Act - Use actingAs to simulate authenticated user
+        $response = $this->actingAs($this->shopUser)
+            ->postJson('/api/shops/reminders', $invalidData);
+
+        // Assert
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['shop_id', 'title', 'description', 'due_date']);
+    }
+
+    /**
+     * Test marking a reminder as done
+     */
+    public function test_marking_reminder_as_done()
+    {
+        // Arrange
+        $shopId = $this->shopUser->id;
+        $reminderId = 1;
+        $updatedReminder = [
+            'id' => $reminderId,
+            'shop_id' => $shopId,
+            'status' => 'completed'
+        ];
+
+        // Mock the repository method
+        $this->reminderRepository
+            ->shouldReceive('markAsDone')
+            ->with($reminderId)
+            ->once()
+            ->andReturn($updatedReminder);
+
+        // Act - Use actingAs to simulate authenticated user
+        $response = $this->actingAs($this->shopUser)
+            ->patchJson("/api/shops/reminders/{$reminderId}");
+
+        // Assert
+        $response->assertStatus(200)
+            ->assertJson(['message' => 'Reminder marked as completed']);
+    }
+
+    /**
+     * Test invalid shop_id when fetching reminders
+     */
+    public function test_fetch_reminders_with_invalid_shop_id()
+    {
+        // Arrange
+        $invalidShopId = 'invalid-id';
+
+        // Act
+        $response = $this->actingAs($this->shopUser)
+            ->getJson("/api/shops/reminders/{$invalidShopId}");
+
+        // Assert
+        $response->assertStatus(400)
+            ->assertJson(['error' => 'shop_id is required']);
+    }
+
+    /**
+     * Test invalid reminder_id when marking as done
+     */
+
+    public function test_marking_reminder_as_done_with_invalid_id()
+    {
+        // Arrange
+        $invalidReminderId = 'invalid-id';
+
+        // Act
+        $response = $this->actingAs($this->shopUser)
+            ->patchJson("/api/shops/reminders/{$invalidReminderId}");
+
+        // Assert
+        $response->assertStatus(400)
+            ->assertJson(['error' => 'Invalid reminder ID']);
+    }
+
+    /**
+     * Test invalid reminder's data when creating reminder
+     */
+
+    public function test_reminder_creation_fails_with_invalid_data()
+    {
+        // Arrange
+        $invalidDataList = [
+            [
+                'shop_id' => 'not-a-number',
+                'title' => 'Valid Title',
+                'description' => 'Valid Description',
+                'due_date' => now()->addDays(3)->format('Y-m-d H:i:s')
+            ],
+            [
+                'shop_id' => 1,
+                'title' => 'Valid Title',
+                'description' => 'Valid Description',
+                'due_date' => 'invalid-date-format'
+            ],
+            [
+                'shop_id' => 1,
+                'title' => '',
+                'description' => '',
+                'due_date' => now()->addDays(3)->format('Y-m-d H:i:s')
+            ]
+        ];
+
+        foreach ($invalidDataList as $invalidData) {
+            // Act
+            $response = $this->actingAs($this->shopUser)
+                ->postJson('/api/shops/reminders', $invalidData);
+
+            // Assert
+            $response->assertStatus(422);
+        }
+    }
+
+
+    public function test_fetch_reminders_fails_with_non_numeric_shop_id()
+    {
+        // Arrange
+        $invalidShopId = 'abc123';
+
+        // Act
+        $response = $this->actingAs($this->shopUser)
+            ->getJson("/api/shops/reminders/{$invalidShopId}");
+
+        // Assert
+        $response->assertStatus(400)
+            ->assertJson(['error' => 'shop_id is required']);
+    }
+
+
+}
+


### PR DESCRIPTION
This pull request includes several updates to the Laravel application, primarily focusing on the reminder functionality. The changes include updates to the CI workflow, enhancements to the `ReminderController`, modifications to the API routes, and the addition of new feature tests.

Enhancements to reminder functionality:

* [`app/Http/Controllers/ReminderController.php`](diffhunk://#diff-ba3963bb35e10249fc2fa2193fbed460655ba4eb1b1d2a178a6d1a6d1a73b1faL50-R64): Improved validation and error handling in the `markAsDone` method to ensure valid reminder IDs and appropriate responses for different scenarios.

API route updates:

* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL102-R102): Updated the route parameter for marking reminders as done from `shop_id` to `reminder_id` to reflect the correct entity being updated.

Continuous Integration updates:

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L5-R5): Added new branches to the CI workflow triggers to include `feature/reminders-testing` and `feature/queue-type-testing`.

New feature tests:

* [`tests/Feature/ShopRemindersTest.php`](diffhunk://#diff-97e86502ec6e51ee91903bcb2bfd020f87050086bcee5f46a4df5e859fe83644R1-R292): Added comprehensive feature tests for the reminder functionality, including tests for fetching reminders, creating reminders, and marking reminders as done.

Configuration updates:

* [`.idea/php-test-framework.xml`](diffhunk://#diff-114cd4784cfe16ec751e8268951ee34f922da7d330c36f30f6c2a495102745adR1-R14): Added configuration for the PHP test framework to cache the version of PHPUnit being used.